### PR TITLE
Skipping errored genesets for BroadEnrich

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: chipenrich
 Type: Package
 Title: Gene Set Enrichment For ChIP-seq Peak Data
-Version: 2.1.5
+Version: 2.1.6
 Date: 2017-10-16
 Authors@R: c(
 	person(c("Ryan","P."),"Welch",role = c("aut","cph"),email = "welchr@umich.edu"),

--- a/R/test_broadenrich.R
+++ b/R/test_broadenrich.R
@@ -74,11 +74,20 @@ single_broadenrich = function(go_id, geneset, gpw, method, model) {
 	r_go_genes_peak_num = length(go_genes_peak)
 	r_go_genes_avg_coverage = mean(gpw$ratio[b_genes])
 
-    fit = mgcv::gam(final_model, data = cbind(gpw, goterm = as.numeric(b_genes)), family = "binomial")
+    tryCatch(
+        {fit = mgcv::gam(final_model, data = cbind(gpw, goterm = as.numeric(b_genes)), family = "binomial")
+            # Results from the logistic regression
+            r_effect = coef(fit)[2];
+            r_pval = summary(fit)$p.table[2, 4]
+        },
+        error = {function(e) {warning(sprintf("Error in geneset: %s. NAs given", go_id))
+            r_effect = NA;
+            r_pval = NA;};
 
-	# Results from the logistic regression
-    r_effect = coef(fit)[2]
-    r_pval = summary(fit)$p.table[2, 4]
+        }
+    )
+    
+
 
 	out = data.frame(
 		"P.value" = r_pval,


### PR DESCRIPTION
Added a workaround for the strange eigen 0x0 hessian bug. Will now warn which gene sets fail. Only done for Broadenrich.